### PR TITLE
Set the device inside of condor_negloglikeloss

### DIFF
--- a/src/condor_pytorch/dataset.py
+++ b/src/condor_pytorch/dataset.py
@@ -46,7 +46,7 @@ def label_to_levels(label, num_classes, dtype=torch.float32):
         int_label = label
 
     levels = [1]*int_label + [0]*(num_classes - 1 - int_label)
-    levels = torch.tensor(levels, dtype=dtype)
+    levels = torch.tensor(levels, dtype=dtype, device=label.device)
     return levels
 
 

--- a/src/condor_pytorch/losses.py
+++ b/src/condor_pytorch/losses.py
@@ -44,7 +44,7 @@ def condor_negloglikeloss(logits, labels, reduction='mean'):
     if not logits.shape == labels.shape:
         raise ValueError("Please ensure that logits (%s) has the same shape as labels (%s). "
                          % (logits.shape, labels.shape))
-    piLab = torch.cat([torch.ones((labels.shape[0],1)),labels[:,:-1]],dim=1)
+    piLab = torch.cat([torch.ones((labels.shape[0],1), device=labels.device),labels[:,:-1]],dim=1)
 
     # The logistic loss formula from above is
     #   x - x * z + log(1 + exp(-x))
@@ -54,7 +54,7 @@ def condor_negloglikeloss(logits, labels, reduction='mean'):
     #   max(x, 0) - x * z + log(1 + exp(-abs(x)))
     # To allow computing gradients at zero, we define custom versions of max and
     # abs functions.
-    zeros = torch.zeros_like(logits, dtype=logits.dtype)
+    zeros = torch.zeros_like(logits, dtype=logits.dtype, device=logits.device)
     cond = (logits >= zeros)
     cond2 = (piLab > zeros)
     relu_logits = torch.where(cond, logits, zeros)


### PR DESCRIPTION
This sets the `device` of the `torch.ones` and `torch.zeros_like` tensors inside of `condor_negloglikeloss` based on the input's device, rather than default.